### PR TITLE
feat: implement logging

### DIFF
--- a/src/webtrigger/types/types.ts
+++ b/src/webtrigger/types/types.ts
@@ -1,6 +1,12 @@
+declare global {
+  // eslint-disable-next-line no-var
+  var requestId: string;
+  // eslint-disable-next-line no-var
+  var verbosity: LoggingLevel;
+}
 export interface WebTriggerRequest {
   queryParameters: {
-    debug?: string[];
+    verbosity?: string[];
   };
   headers: {
     authorization: string[];
@@ -106,4 +112,12 @@ interface Key {
   kid: string;
   kty: string;
   n: string;
+}
+
+export enum LoggingLevel {
+  ERROR = 0,
+  WARN = 1,
+  INFO = 2,
+  DEBUG = 3,
+  LOG = 4,
 }

--- a/src/webtrigger/utils/logger.ts
+++ b/src/webtrigger/utils/logger.ts
@@ -1,0 +1,37 @@
+import { LoggingLevel } from '../types/types';
+
+function print(
+  message: object | string,
+  level: Console['debug'] | Console['error'] | Console['info'] | Console['log'] | Console['warn'],
+  ...optionalParams: unknown[]
+): void {
+  const strMessage = typeof message === 'string' ? message : JSON.stringify(message);
+  const requestId = global.requestId;
+  level(`${requestId} ${strMessage}`, ...optionalParams);
+}
+
+export function printDebug(message: object | string, ...optionalParams: unknown[]): void {
+  if (global.verbosity >= LoggingLevel.DEBUG) print(message, console.debug, ...optionalParams);
+}
+
+export function printError(message: object | string, ...optionalParams: unknown[]): void {
+  if (global.verbosity >= LoggingLevel.ERROR) print(message, console.error, ...optionalParams);
+}
+
+export function printInfo(message: object | string, ...optionalParams: unknown[]): void {
+  if (global.verbosity >= LoggingLevel.INFO) print(message, console.info, ...optionalParams);
+}
+
+export function printLog(message: object | string, ...optionalParams: unknown[]): void {
+  if (global.verbosity >= LoggingLevel.LOG) print(message, console.log, ...optionalParams);
+}
+
+export function printWarn(message: object | string, ...optionalParams: unknown[]): void {
+  if (global.verbosity >= LoggingLevel.WARN) print(message, console.warn, ...optionalParams);
+}
+
+export function parseLevel(verbosityString: string | undefined): LoggingLevel {
+  return verbosityString && verbosityString.toUpperCase() in LoggingLevel
+    ? LoggingLevel[verbosityString.toUpperCase() as keyof typeof LoggingLevel]
+    : LoggingLevel.ERROR;
+}


### PR DESCRIPTION
## Changes

This PR introduces a logger functionality that follows an ordinality set by the verbosity level. It is heavily inspired by [Winston](https://github.com/winstonjs/winston#logging-levels).

For now, I'm keeping the logging to a minimum to avoid cluttering the code. As time goes on and more people use the app, we can identify optimal spots to introduce logging and adequately set their level. 