### PR TITLE
Set pnpm minimumReleaseAge to 7200

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+minimumReleaseAge: 7200
 packages:
   - "apps/*"
   - "packages/*"


### PR DESCRIPTION
## Summary

Sets `minimumReleaseAge: 7200` in `pnpm-workspace.yaml`. This enforces a minimum release age of 5 days (7200 minutes) for pnpm dependencies, reducing risk from supply chain attacks by ensuring newly published package versions have had time for community review before being installed.